### PR TITLE
High level integration tests

### DIFF
--- a/tests/resources/integration_test_data/assetized_child_ref_non_assetized_grandchild/bal_library.json
+++ b/tests/resources/integration_test_data/assetized_child_ref_non_assetized_grandchild/bal_library.json
@@ -1,0 +1,15 @@
+{
+  "entities": {
+    "floor": {
+      "versions": [
+        {
+          "traits": {
+            "openassetio-mediacreation:content.LocatableContent": {
+              "location": "file:///${TEST_DATA_ROOT}/assetized_child_ref_non_assetized_grandchild/floor1.usd"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/resources/integration_test_data/assetized_child_ref_non_assetized_grandchild/car.usd
+++ b/tests/resources/integration_test_data/assetized_child_ref_non_assetized_grandchild/car.usd
@@ -1,0 +1,5 @@
+#usda 1.0
+def "Car"
+{
+    color3f color = (0, 0, 0)
+}

--- a/tests/resources/integration_test_data/assetized_child_ref_non_assetized_grandchild/floor1.usd
+++ b/tests/resources/integration_test_data/assetized_child_ref_non_assetized_grandchild/floor1.usd
@@ -1,0 +1,14 @@
+#usda 1.0
+def "ParkingLot_Floor"
+{
+    def "Car1" (
+        references = @car.usd@</Car>
+    )
+    {
+    }
+    def "Car2" (
+        references = @car.usd@</Car>
+    )
+    {
+    }
+}

--- a/tests/resources/integration_test_data/assetized_child_ref_non_assetized_grandchild/parking_lot.usd
+++ b/tests/resources/integration_test_data/assetized_child_ref_non_assetized_grandchild/parking_lot.usd
@@ -1,0 +1,11 @@
+#usda 1.0
+
+def "ParkingLot"
+{
+    def "ParkingLot_Floor_1" (
+        references = @bal:///floor@</ParkingLot_Floor>
+    )
+    {
+    }
+}
+

--- a/tests/resources/integration_test_data/non_assetized_child_ref_assetized_grandchild/bal_library.json
+++ b/tests/resources/integration_test_data/non_assetized_child_ref_assetized_grandchild/bal_library.json
@@ -1,0 +1,15 @@
+{
+  "entities": {
+    "car": {
+      "versions": [
+        {
+          "traits": {
+            "openassetio-mediacreation:content.LocatableContent": {
+              "location": "file:///${TEST_DATA_ROOT}/non_assetized_child_ref_assetized_grandchild/car.usd"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/resources/integration_test_data/non_assetized_child_ref_assetized_grandchild/car.usd
+++ b/tests/resources/integration_test_data/non_assetized_child_ref_assetized_grandchild/car.usd
@@ -1,0 +1,5 @@
+#usda 1.0
+def "Car"
+{
+    color3f color = (0, 0, 0)
+}

--- a/tests/resources/integration_test_data/non_assetized_child_ref_assetized_grandchild/floor1.usd
+++ b/tests/resources/integration_test_data/non_assetized_child_ref_assetized_grandchild/floor1.usd
@@ -1,0 +1,14 @@
+#usda 1.0
+def "ParkingLot_Floor"
+{
+    def "Car1" (
+        references = @bal:///car@</Car>
+    )
+    {
+    }
+    def "Car2" (
+        references = @bal:///car@</Car>
+    )
+    {
+    }
+}

--- a/tests/resources/integration_test_data/non_assetized_child_ref_assetized_grandchild/parking_lot.usd
+++ b/tests/resources/integration_test_data/non_assetized_child_ref_assetized_grandchild/parking_lot.usd
@@ -1,0 +1,11 @@
+#usda 1.0
+
+def "ParkingLot"
+{
+    def "ParkingLot_Floor_1" (
+        references = @floor1.usd@</ParkingLot_Floor>
+    )
+    {
+    }
+}
+

--- a/tests/resources/integration_test_data/recursive_assetized_resolve/bal_library.json
+++ b/tests/resources/integration_test_data/recursive_assetized_resolve/bal_library.json
@@ -1,0 +1,26 @@
+{
+  "entities": {
+    "floor": {
+      "versions": [
+        {
+          "traits": {
+            "openassetio-mediacreation:content.LocatableContent": {
+              "location": "file:///${TEST_DATA_ROOT}/recursive_assetized_resolve/floors/floor1.usd"
+            }
+          }
+        }
+      ]
+    },
+    "car": {
+      "versions": [
+        {
+          "traits": {
+            "openassetio-mediacreation:content.LocatableContent": {
+              "location": "file:///${TEST_DATA_ROOT}/recursive_assetized_resolve/cars/car.usd"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/resources/integration_test_data/recursive_assetized_resolve/cars/car.usd
+++ b/tests/resources/integration_test_data/recursive_assetized_resolve/cars/car.usd
@@ -1,0 +1,5 @@
+#usda 1.0
+def "Car"
+{
+    color3f color = (0, 0, 0)
+}

--- a/tests/resources/integration_test_data/recursive_assetized_resolve/floors/floor1.usd
+++ b/tests/resources/integration_test_data/recursive_assetized_resolve/floors/floor1.usd
@@ -1,0 +1,14 @@
+#usda 1.0
+def "ParkingLot_Floor"
+{
+    def "Car1" (
+        references = @bal:///car@</Car>
+    )
+    {
+    }
+    def "Car2" (
+        references = @bal:///car@</Car>
+    )
+    {
+    }
+}

--- a/tests/resources/integration_test_data/recursive_assetized_resolve/parking_lot.usd
+++ b/tests/resources/integration_test_data/recursive_assetized_resolve/parking_lot.usd
@@ -1,0 +1,11 @@
+#usda 1.0
+
+def "ParkingLot"
+{
+    def "ParkingLot_Floor_1" (
+        references = @bal:///floor@</ParkingLot_Floor>
+    )
+    {
+    }
+}
+

--- a/tests/resources/integration_test_data/resolver_has_no_effect_with_no_search_path/car.usd
+++ b/tests/resources/integration_test_data/resolver_has_no_effect_with_no_search_path/car.usd
@@ -1,0 +1,5 @@
+#usda 1.0
+def "Car"
+{
+    color3f color = (0, 0, 0)
+}

--- a/tests/resources/integration_test_data/resolver_has_no_effect_with_no_search_path/floor1.usd
+++ b/tests/resources/integration_test_data/resolver_has_no_effect_with_no_search_path/floor1.usd
@@ -1,0 +1,14 @@
+#usda 1.0
+def "ParkingLot_Floor"
+{
+    def "Car1" (
+        references = @car.usd@</Car>
+    )
+    {
+    }
+    def "Car2" (
+        references = @car.usd@</Car>
+    )
+    {
+    }
+}

--- a/tests/resources/integration_test_data/resolver_has_no_effect_with_no_search_path/parking_lot.usd
+++ b/tests/resources/integration_test_data/resolver_has_no_effect_with_no_search_path/parking_lot.usd
@@ -1,0 +1,11 @@
+#usda 1.0
+
+def "ParkingLot"
+{
+    def "ParkingLot_Floor_1" (
+        references = @floor1.usd@</ParkingLot_Floor>
+    )
+    {
+    }
+}
+

--- a/tests/resources/integration_test_data/resolver_has_no_effect_with_search_path/parking_lot.usd
+++ b/tests/resources/integration_test_data/resolver_has_no_effect_with_search_path/parking_lot.usd
@@ -1,0 +1,11 @@
+#usda 1.0
+
+def "ParkingLot"
+{
+    def "ParkingLot_Floor_1" (
+        references = @floors/floor1.usd@</ParkingLot_Floor>
+    )
+    {
+    }
+}
+

--- a/tests/resources/integration_test_data/resolver_has_no_effect_with_search_path/search_path_root/cars/car.usd
+++ b/tests/resources/integration_test_data/resolver_has_no_effect_with_search_path/search_path_root/cars/car.usd
@@ -1,0 +1,5 @@
+#usda 1.0
+def "Car"
+{
+    color3f color = (0, 0, 0)
+}

--- a/tests/resources/integration_test_data/resolver_has_no_effect_with_search_path/search_path_root/floors/floor1.usd
+++ b/tests/resources/integration_test_data/resolver_has_no_effect_with_search_path/search_path_root/floors/floor1.usd
@@ -1,0 +1,14 @@
+#usda 1.0
+def "ParkingLot_Floor"
+{
+    def "Car1" (
+        references = @cars/car.usd@</Car>
+    )
+    {
+    }
+    def "Car2" (
+        references = @cars/car.usd@</Car>
+    )
+    {
+    }
+}

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -10,9 +10,16 @@ import pytest
 
 # This environment var must be set before the usd imports.
 os.environ["TF_DEBUG"] = "OPENASSETIO_RESOLVER"
-from pxr import Usd
+from pxr import Plug, Usd, Ar
 
 
+# Assume OpenAssetIO is configured as the custom primary resolver for
+# all tests. If you're wondering where this is configured, it may
+# just be set via the `PXR_PLUGINPATH_NAME` environment variable.
+
+
+# This test can be removed once the logging transforms, alchemy like,
+# into real functionality.
 def test_open_stage_and_logging(capfd):
     Usd.Stage.Open("resources/empty_shot.usda")
     captured = capfd.readouterr()
@@ -26,3 +33,126 @@ def test_open_stage_and_logging(capfd):
     assert "_OpenAsset" in outputs[6]
     assert "_GetModificationTimestamp" in outputs[7]
     assert "_GetExtension" in outputs[8]
+
+
+# Given a USD document that references an asset via a direct relative
+# file path, then the asset is resolved to the file path as expected.
+def test_openassetio_resolver_has_no_effect_with_no_search_path():
+
+    stage = open_stage(
+        "resources/integration_test_data/resolver_has_no_effect_with_no_search_path/parking_lot.usd"
+    )
+
+    assert_parking_lot_structure(stage)
+
+
+# Given a USD document that references an asset via a relative
+# search-path based file path, then the asset is resolved to the file
+# path as expected.
+def test_openassetio_resolver_has_no_effect_with_search_path():
+
+    context = build_search_path_context(
+        "resources/integration_test_data/resolver_has_no_effect_with_search_path/search_path_root"
+    )
+    stage = open_stage(
+        "resources/integration_test_data/resolver_has_no_effect_with_search_path/parking_lot.usd",
+        context,
+    )
+
+    assert_parking_lot_structure(stage)
+
+
+# Given a USD document that references a second level document via an
+# assetized reference resolvable by OpenAssetIO, and that second
+# level document containing an assetized reference resolvable by
+# OpenAssetIO to a third level document, and that the resolved paths
+# are search path based, then the document can be fully resolved.
+@pytest.mark.xfail(reason="OpenAssetIO not integrated yet")
+def test_recursive_assetized_resolve():
+    stage = open_stage(
+        "resources/integration_test_data/recursive_assetized_resolve/parking_lot.usd"
+    )
+
+    assert_parking_lot_structure(stage)
+
+
+# Given a USD document that references a second level document via an
+# assetized reference resolvable by OpenAssetIO, and that second level
+# document containing a non-assetized, adjacent relative file path
+# reference to a third level document, then the document can be fully
+# resolved.
+@pytest.mark.xfail(reason="OpenAssetIO not integrated yet")
+def test_assetized_child_ref_non_assetized_grandchild():
+    stage = open_stage(
+        "resources/integration_test_data"
+        "/assetized_child_ref_non_assetized_grandchild/parking_lot.usd"
+    )
+
+    assert_parking_lot_structure(stage)
+
+
+# Given a USD document that references a second level document via an
+# non-assetized, adjacent relative file path reference, and that second
+# level document containing an assetized reference resolvable by
+# OpenAssetIO to a third level document, then the document can be fully
+# resolved.
+@pytest.mark.xfail(reason="OpenAssetIO not integrated yet")
+def test_non_assetized_child_ref_assetized_grandchild():
+    stage = open_stage(
+        "resources/integration_test_data"
+        "/non_assetized_child_ref_assetized_grandchild/parking_lot.usd"
+    )
+
+    assert_parking_lot_structure(stage)
+
+
+##### Utility Functions #####
+
+# Verify OpenAssetIO configured as the AR resolver.
+@pytest.fixture(autouse=True)
+def openassetio_configured():
+    plugin_registry = Plug.Registry()
+    plugin = plugin_registry.GetPluginWithName("usdOpenAssetIOResolver")
+
+    assert (
+        plugin is not None
+    ), "usdOpenAssetIOResolver plugin not loaded, please check PXR_PLUGINPATH_NAME env variable"
+
+
+# As all the data tends to follow the same form, convenience method
+# to avoid repeating myself
+def assert_parking_lot_structure(usd_stage):
+    floor = usd_stage.GetPrimAtPath("/ParkingLot/ParkingLot_Floor_1")
+
+    assert floor.IsValid()
+
+    car1 = floor.GetChild("Car1")
+    car2 = floor.GetChild("Car2")
+
+    assert car1.IsValid()
+    assert car2.IsValid()
+
+    assert car1.GetPropertyNames() == ["color"]
+    assert car2.GetPropertyNames() == ["color"]
+
+
+# Set the default resolver search path to a subdirectory
+# Done this way so that you can run the test from any directory,
+# otherwise the working directory will impact the file loading.
+def build_search_path_context(path_relative_from_file):
+    script_dir = os.path.realpath(os.path.dirname(__file__))
+    full_path = os.path.join(script_dir, path_relative_from_file)
+    return Ar.DefaultResolverContext([full_path])
+
+
+# Open the stage
+# Done this way so that you can run the test from any directory,
+# otherwise the working directory will impact the file loading.
+def open_stage(path_relative_from_file, context=None):
+    script_dir = os.path.realpath(os.path.dirname(__file__))
+    full_path = os.path.join(script_dir, path_relative_from_file)
+
+    if context is not None:
+        return Usd.Stage.Open(full_path, context)
+
+    return Usd.Stage.Open(full_path)


### PR DESCRIPTION
Closes #12 

Add a set of high level integration tests, and data to go with them. All they do is load a USD stage, then verify that it manages to find the properties of the branch prims.

These tests assert the basic workflow of loading a USD document with resolvable references in it, as well as that the OpenAssetIO resolver dosen't override or interfere with USD standard resolution mechanisms.

For any test dataset that expects OpenAssetIO to resolve a LocatableContent trait, a BAL format library has been included with the dataset to document that path strings that should be returns, although no effort has been made to integrate OpenAssetIO or BAL, the formatting choice is purely speculative.