### PR TITLE
[Build] Integrate OpenAssetIO

### DIFF
--- a/.github/build_openassetio/action.yml
+++ b/.github/build_openassetio/action.yml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023 The Foundry Visionmongers Ltd
+
+# Composite action for reuse within other workflows.
+# Builds OpenAssetIO.
+# Should be run on a ghcr.io/openassetio/openassetio-build container.
+
+name: Build OpenAssetIO
+description: Builds OpenAssetIO and publishes an artifact
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout OpenAssetIO
+      uses: actions/checkout@v3
+      with:
+        repository: OpenAssetIO/OpenAssetIO
+        path: openassetio-checkout
+
+    - name: Build OpenAssetIO
+      shell: bash
+      run: |
+        cd openassetio-checkout
+        mkdir build
+        cmake -G Ninja -S . -B build
+        cmake --build build
+        cmake --install build
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: OpenAssetIO Build
+        path: openassetio-checkout/build/dist
+        retention-days: 1

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -11,10 +11,6 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: aswf/ci-vfxall:2022-clang13.1
-    strategy:
-      matrix:
-        config:
-          - os: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 
@@ -48,15 +44,20 @@ jobs:
       - name: Check Python formatting
         run: black tests --check .
 
-  # Note: in order to keep an `actions/cache` cache up to date, we must
-  # use the approach detailed in
-  # https://github.com/actions/cache/blob/main/workarounds.md#update-a-cache
-  # i.e. load the most recently created cache that matches a prefix,
-  # then create an entirely new cache with every run.
+  build-openassetio:
+    name: Build OpenAssetIO
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/openassetio/openassetio-build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build
+        uses: ./.github/build_openassetio
 
   cpp-linters:
     name: C++ linters
     runs-on: ubuntu-20.04
+    needs: build-openassetio
     container:
       image: aswf/ci-vfxall:2022-clang13.1
     strategy:
@@ -66,34 +67,27 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Cache ccache cache
-        uses: actions/cache@v3
-        with:
-          path: /tmp/ccache
-          key: ubuntu-20.04-ccache-lint-${{ github.run_id }}
-          restore-keys: ubuntu-20.04-ccache-lint-
-
       - name: Install dependencies
         # Configure the system and install library dependencies via
         # conan packages.
         run: |
           python -m pip install -r resources/build/linter-requirements.txt
-          yum -y install ccache
           clang-tidy --version
           clang-format --version
           cpplint --version
+
+      - name: Get OpenAssetIO
+        uses: actions/download-artifact@v3
+        with:
+          name: OpenAssetIO Build
+          path: ./openassetio-build
+
       - name: Configure CMake build
         run: >
-          cmake -S . -B build -G Ninja
-          -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache
-          -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache
+          cmake -DCMAKE_PREFIX_PATH="./openassetio-build" -S . -B build -G Ninja
           --install-prefix ${{ github.workspace }}/dist
           --preset lint
 
       - name: Build and lint
         run: |
-          /usr/bin/ccache -s
           cmake --build build
-          /usr/bin/ccache -s
-        env:
-          CCACHE_DIR: /tmp/ccache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,24 +11,54 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-openassetio:
+    name: Build OpenAssetIO
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/openassetio/openassetio-build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build
+        uses: ./.github/build_openassetio
+
   test:
     name: Test-Resolver
     runs-on: ubuntu-latest
+    needs: build-openassetio
     container:
       image: aswf/ci-vfxall:2022-clang13.1
     steps:
       - uses: actions/checkout@v3
 
-      - name: Build and install (Docker)
-        run: >
-          cmake -S . -B build &&
-          cmake --build build &&
+      - name: Get OpenAssetIO
+        uses: actions/download-artifact@v3
+        with:
+          name: OpenAssetIO Build
+          path: ./openassetio-build
+
+      - name: Build and install Resolver
+        run: |
+          cmake -S . -DCMAKE_PREFIX_PATH="./openassetio-build" -B build
+          cmake --build build
           cmake --install build
 
       - run: |
           python -m pip install -r tests/requirements.txt
 
+        # PYTHONPATH here is extended with `/usr/local/lib/python`
+        # because the USD install on this docker container is odd, and
+        # stores the `pxr` lib in that space, whilst the regular python
+        # libraries are contained at /usr/local/lib/python3.9,
+        # (which is already on the pythonpath)
+        #
+        # LD_LIBRARY_PATH doesn't have /usr/local/lib on it by default
+        # like you might expect because we're running as root, so we
+        # just append it (it's so we can find python itself.)
       - name: Test
-        run: >
+        run: |
+          export PXR_PLUGINPATH_NAME=$GITHUB_WORKSPACE/build/dist/resources/plugInfo.json
+          export LD_LIBRARY_PATH=/usr/local/lib:$GITHUB_WORKSPACE/openassetio-build/lib64
+          export OPENASSETIO_DEFAULT_CONFIG=$GITHUB_WORKSPACE/tests/resources/openassetio.conf
+          export PYTHONPATH=/usr/local/lib/python/:$GITHUB_WORKSPACE/openassetio-build/lib/python3.9/site-packages
           cd tests
           python -m pytest . -v

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 # 1. Requirements
-project(usdOpenAssetIOResolver)
 cmake_minimum_required(VERSION 3.21)
+
+project(
+usdOpenAssetIOResolver
+VERSION 1.0.0
+)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -17,29 +21,6 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND PROJECT_IS_TOP_LEVEL)
     set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/dist" CACHE PATH "Installation location" FORCE)
 endif ()
-
-add_compile_options(-Wno-deprecated)  # This is just to avoid some spammy warnings
-
-# Find USD.
-# This searches for the `pxrConfig.cmake` file that USD provides, using
-# cmakes config search mode. Normally the USD directory will be on the
-# system path as per the install, so it will be found.
-find_package(pxr REQUIRED)
-
-# Add Static analysis targets
-include(StaticAnalyzers)
-if (OPENASSETIO_USDRESOLVER_ENABLE_CLANG_FORMAT)
-    enable_clang_format()
-endif ()
-if (OPENASSETIO_USDRESOLVER_ENABLE_CLANG_TIDY)
-    enable_clang_tidy()
-endif ()
-if (OPENASSETIO_USDRESOLVER_ENABLE_CPPLINT)
-    enable_cpplint()
-endif ()
-
-include(CompilerWarnings)
-add_subdirectory(src)
 
 #-----------------------------------------------------------------------
 # Lint options
@@ -58,9 +39,44 @@ option(OPENASSETIO_USDRESOLVER_ENABLE_CLANG_TIDY "Enable clang-tidy analysis dur
 # Enable cpplint linter.
 option(OPENASSETIO_USDRESOLVER_ENABLE_CPPLINT "Enable cpplint linter during build" OFF)
 
+
+# Disable C++11 ABI by default, as per current VFX reference
+# platform(s), but allow optionally enabling.
+# For reference, note that the default varies by platform, e.g.
+# * CentOS 7.9.2009's GCC 6.3, `_GLIBCXX_USE_CXX11_ABI` is
+#   always `0` and cannot be overridden.
+# * Ubuntu 18.04's GCC 6.5, `_GLIBCXX_USE_CXX11_ABI` defaults
+#   to `1`, but can be overridden.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
+    CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 5.0)
+    option(OPENASSETIO_USDRESOLVER_GLIBCXX_USE_CXX11_ABI "For gcc, use the new C++11 library ABI" OFF)
+endif ()
+
+
+# Find USD.
+find_package(pxr REQUIRED)
+
+# Find OpenAssetIO
+find_package(OpenAssetIO REQUIRED)
+
+# Add Static analysis targets
+include(StaticAnalyzers)
+if (OPENASSETIO_USDRESOLVER_ENABLE_CLANG_FORMAT)
+    enable_clang_format()
+endif ()
+if (OPENASSETIO_USDRESOLVER_ENABLE_CLANG_TIDY)
+    enable_clang_tidy()
+endif ()
+if (OPENASSETIO_USDRESOLVER_ENABLE_CPPLINT)
+    enable_cpplint()
+endif ()
+
+include(DefaultTargetProperties)
+add_subdirectory(src)
+
 #-----------------------------------------------------------------------
 # Print a status dump
 message(STATUS "Warnings as errors              = ${OPENASSETIO_USDRESOLVER_WARNINGS_AS_ERRORS}")
-message(STATUS "Linter: clang-tidy              = ${OPENASSETIO_USDRESOLVER_ENABLE_CLANG_TIDY} [${OPENASSETIO_CLANGTIDY_EXE}]")
-message(STATUS "Linter: cpplint                 = ${OPENASSETIO_USDRESOLVER_ENABLE_CPPLINT} [${OPENASSETIO_CPPLINT_EXE}]")
-message(STATUS "Linter: clang-format            = ${OPENASSETIO_USDRESOLVER_ENABLE_CLANG_FORMAT} [${OPENASSETIO_CLANGFORMAT_EXE}]")
+message(STATUS "Linter: clang-tidy              = ${OPENASSETIO_USDRESOLVER_ENABLE_CLANG_TIDY} [${OPENASSETIO_USDRESOLVER_CLANGTIDY_EXE}]")
+message(STATUS "Linter: cpplint                 = ${OPENASSETIO_USDRESOLVER_ENABLE_CPPLINT} [${OPENASSETIO_USDRESOLVER_CPPLINT_EXE}]")
+message(STATUS "Linter: clang-format            = ${OPENASSETIO_USDRESOLVER_ENABLE_CLANG_FORMAT} [${OPENASSETIO_USDRESOLVER_CLANGFORMAT_EXE}]")

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2013-2022 The Foundry Visionmongers Ltd
 
-function(set_default_compiler_warnings target_name)
+function(openassetio_usdresolver_set_default_compiler_warnings target_name)
 
     set(CLANG_WARNINGS
         -Wall

--- a/cmake/DefaultTargetProperties.cmake
+++ b/cmake/DefaultTargetProperties.cmake
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2013-2022 The Foundry Visionmongers Ltd
+
+include(CompilerWarnings)
+
+function(openassetio_usdresolver_set_default_target_properties target_name)
+    #-------------------------------------------------------------------
+    # C++ standard
+
+    # Minimum C++ standard as per current VFX reference platform CY21+.
+    target_compile_features(${target_name} PRIVATE cxx_std_17)
+
+    set_target_properties(
+        ${target_name}
+        PROPERTIES
+        # Ensure the proposed compiler supports our minimum C++
+        # standard.
+        CXX_STANDARD_REQUIRED ON
+        # Disable compiler extensions. E.g. use -std=c++11  instead of
+        # -std=gnu++11.  Helps limit cross-platform issues.
+        CXX_EXTENSIONS OFF
+    )
+
+    #-------------------------------------------------------------------
+    # Compiler warnings
+    openassetio_usdresolver_set_default_compiler_warnings(${target_name})
+
+    #-------------------------------------------------------------------
+    # Symbol visibility
+
+    # Hide symbols from this library by default.
+    set_target_properties(
+        ${target_name}
+        PROPERTIES
+        C_VISIBILITY_PRESET hidden
+        CXX_VISIBILITY_PRESET hidden
+        VISIBILITY_INLINES_HIDDEN YES
+    )
+
+    # Hide all symbols from external statically linked libraries.
+    if (IS_GCC_OR_CLANG AND NOT APPLE)
+        # TODO(TC): Find a way to hide symbols on macOS
+        target_link_options(${target_name} PRIVATE "-Wl,--exclude-libs,ALL")
+    endif ()
+
+    # Whether to use the old or new C++ ABI with gcc.
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
+        CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 5.0)
+        if (OPENASSETIO_USDRESOLVER_GLIBCXX_USE_CXX11_ABI)
+            target_compile_definitions(${target_name} PRIVATE _GLIBCXX_USE_CXX11_ABI=1)
+        else ()
+            target_compile_definitions(${target_name} PRIVATE _GLIBCXX_USE_CXX11_ABI=0)
+        endif ()
+    endif ()
+
+    #-------------------------------------------------------------------
+    # Library version
+
+    get_target_property(target_type ${target_name} TYPE)
+
+    if (NOT ${target_type} STREQUAL EXECUTABLE)
+        # When building or installing appropriate symlinks are created, if
+        # supported.
+        set_target_properties(
+            ${target_name}
+            PROPERTIES
+            VERSION ${PROJECT_VERSION}
+            SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+        )
+    endif ()
+
+    #-------------------------------------------------------------------
+    # Linters/analyzers
+
+    if (TARGET openassetio-usdresolver-cpplint)
+        add_dependencies(${target_name} openassetio-usdresolver-cpplint)
+    endif ()
+
+    if (TARGET openassetio-usdresolver-clangformat)
+        add_dependencies(${target_name} openassetio-usdresolver-clangformat)
+    endif ()
+
+endfunction()

--- a/cmake/StaticAnalyzers.cmake
+++ b/cmake/StaticAnalyzers.cmake
@@ -2,11 +2,11 @@
 # Copyright 2013-2022 The Foundry Visionmongers Ltd
 
 macro(enable_clang_tidy)
-    find_program(OPENASSETIO_CLANGTIDY_EXE NAMES clang-tidy clang-tidy-12)
+    find_program(OPENASSETIO_USDRESOLVER_CLANGTIDY_EXE NAMES clang-tidy clang-tidy-12)
 
-    if (OPENASSETIO_CLANGTIDY_EXE)
+    if (OPENASSETIO_USDRESOLVER_CLANGTIDY_EXE)
         # Construct the clang-tidy command line
-        set(CMAKE_CXX_CLANG_TIDY ${OPENASSETIO_CLANGTIDY_EXE})
+        set(CMAKE_CXX_CLANG_TIDY ${OPENASSETIO_USDRESOLVER_CLANGTIDY_EXE})
         # Ignore unknown compiler flag check, otherwise e.g. GCC-only
         # compiler warning flags will cause the build to fail.
         list(APPEND CMAKE_CXX_CLANG_TIDY -extra-arg=-Wno-unknown-warning-option)
@@ -25,17 +25,17 @@ macro(enable_clang_tidy)
 endmacro()
 
 macro(enable_cpplint)
-    find_program(OPENASSETIO_CPPLINT_EXE cpplint)
-    if (OPENASSETIO_CPPLINT_EXE)
+    find_program(OPENASSETIO_USDRESOLVER_CPPLINT_EXE cpplint)
+    if (OPENASSETIO_USDRESOLVER_CPPLINT_EXE)
         # Create a custom target to be added as a dependency to other
         # targets. Unfortunately the CMAKE_CXX_CPPLINT integration is
         # somewhat lacking - it won't fail the build and it won't check
         # headers. So we must roll our own target.
         add_custom_target(
-            openassetio-cpplint
+            openassetio-usdresolver-cpplint
             COMMAND ${CMAKE_COMMAND} -E echo "Executing cpplint check..."
             COMMAND
-            ${OPENASSETIO_CPPLINT_EXE}
+            ${OPENASSETIO_USDRESOLVER_CPPLINT_EXE}
             # The default "build/include_order" check suffers from
             # false positives since the default behaviour is to assume
             # that all `<header.h>`-like includes are C headers.
@@ -54,8 +54,8 @@ macro(enable_cpplint)
 endmacro()
 
 macro(enable_clang_format)
-    find_program(OPENASSETIO_CLANGFORMAT_EXE NAMES clang-format clang-format-12)
-    if (OPENASSETIO_CLANGFORMAT_EXE)
+    find_program(OPENASSETIO_USDRESOLVER_CLANGFORMAT_EXE NAMES clang-format clang-format-12)
+    if (OPENASSETIO_USDRESOLVER_CLANGFORMAT_EXE)
         file(
             GLOB_RECURSE _sources
             LIST_DIRECTORIES false
@@ -67,10 +67,10 @@ macro(enable_clang_format)
         # Create a custom target to be added as a dependency to other
         # targets.
         add_custom_target(
-            openassetio-clangformat
+            openassetio-usdresolver-clangformat
             COMMAND ${CMAKE_COMMAND} -E echo "Executing clang-format check..."
             COMMAND
-            ${OPENASSETIO_CLANGFORMAT_EXE}
+            ${OPENASSETIO_USDRESOLVER_CLANGFORMAT_EXE}
             --Werror --dry-run --style=file
             ${_sources}
         )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@
 set(PLUGIN_NAME usdOpenAssetIOResolver)
 
 set(
-  SRC
+    SRC
     resolver.cpp
 )
 
@@ -12,38 +12,35 @@ add_library(${PLUGIN_NAME}
 )
 
 target_link_libraries(${PLUGIN_NAME}
-    PUBLIC
+    PRIVATE
     ar
+    OpenAssetIO::openassetio-core
+    OpenAssetIO::openassetio-python-bridge
 )
 
 #-----------------------------------------------------------------------
 # Activate warnings as errors, pedantic, etc.
-set_default_compiler_warnings(${PLUGIN_NAME})
+openassetio_usdresolver_set_default_target_properties(${PLUGIN_NAME})
 
-
-#-----------------------------------------------------------------------
-# Add static analysis dependencies
-if (OPENASSETIO_USDRESOLVER_ENABLE_CLANG_FORMAT)
-    add_dependencies(${PLUGIN_NAME} openassetio-clangformat)
-endif ()
-if (OPENASSETIO_USDRESOLVER_ENABLE_CPPLINT)
-    add_dependencies(${PLUGIN_NAME} openassetio-cpplint)
-endif ()
+# ----------------------------------------------------------------------
+# Silence warnings about deprecation from USD itself
+# At time of writing, from : from USD/include/pxr/base/tf/hashset.h:39
+target_compile_options(${PLUGIN_NAME} PRIVATE -Wno-deprecated)
 
 #-----------------------------------------------------------------------
 # Main install
 install(
     TARGETS
-        ${PLUGIN_NAME}
+    ${PLUGIN_NAME}
     DESTINATION
-        .
+    .
 )
 
 #-----------------------------------------------------------------------
 # Install plugInfo.json
 install(
     FILES
-		resources/plugInfo.json
+	resources/plugInfo.json
     DESTINATION
-        ./resources
+    ./resources
 )

--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -3,13 +3,19 @@
 
 #include "resolver.h"
 
-#include <utility>
+#include <pxr/base/tf/debug.h>
+#include <pxr/base/tf/diagnostic.h>
+#include <pxr/usd/ar/assetInfo.h>
+#include <pxr/usd/ar/defaultResolver.h>
+#include <pxr/usd/ar/defineResolver.h>
 
-#include "pxr/base/tf/debug.h"
-#include "pxr/base/tf/diagnostic.h"
-#include "pxr/usd/ar/assetInfo.h"
-#include "pxr/usd/ar/defaultResolver.h"
-#include "pxr/usd/ar/defineResolver.h"
+#include <openassetio/hostApi/HostInterface.hpp>
+#include <openassetio/hostApi/Manager.hpp>
+#include <openassetio/hostApi/ManagerFactory.hpp>
+#include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
+#include <openassetio/log/SeverityFilter.hpp>
+#include <openassetio/python/hostApi.hpp>
 
 // NOLINTNEXTLINE
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -21,103 +27,177 @@ TF_DEBUG_CODES(OPENASSETIO_RESOLVER)
 
 PXR_NAMESPACE_CLOSE_SCOPE
 
+namespace {
+/// Converter logger from OpenAssetIO log framing to USD log outputs.
+class UsdOpenAssetIOResolverLogger : public openassetio::log::LoggerInterface {
+ public:
+  void log(Severity severity, const openassetio::Str &message) override {
+    switch (severity) {
+      case Severity::kCritical:
+        TF_ERROR(TfDiagnosticType::TF_DIAGNOSTIC_FATAL_ERROR_TYPE, message);
+        break;
+      case Severity::kDebug:
+      case Severity::kDebugApi:
+        TF_DEBUG(OPENASSETIO_RESOLVER).Msg(message + "\n");
+        break;
+      case Severity::kError:
+        // TODO(EM) : Review to see which error types are most appropriate,
+        //  are all errors (not criticals) non fatal?
+        TF_ERROR(TfDiagnosticType::TF_DIAGNOSTIC_NONFATAL_ERROR_TYPE, message);
+        break;
+      case Severity::kInfo:
+      case Severity::kProgress:
+        TF_INFO(OPENASSETIO_RESOLVER).Msg(message + "\n");
+        break;
+      case Severity::kWarning:
+        TF_WARN(TfDiagnosticType::TF_DIAGNOSTIC_WARNING_TYPE, message);
+        break;
+    }
+  }
+};
+
+class UsdOpenAssetIOHostInterface : public openassetio::hostApi::HostInterface {
+ public:
+  [[nodiscard]] openassetio::Identifier identifier() const override {
+    return "org.openassetio.usdresolver";
+  }
+
+  [[nodiscard]] openassetio::Str displayName() const override {
+    return "OpenAssetIO USD Resolver";
+  }
+};
+}  // namespace
+
 // ------------------------------------------------------------
 /* Ar Resolver Implementation */
 UsdOpenAssetIOResolver::UsdOpenAssetIOResolver() {
-  TF_DEBUG(OPENASSETIO_RESOLVER).Msg("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME() + "\n");
+  logger_ =
+      openassetio::log::SeverityFilter::make(std::make_shared<UsdOpenAssetIOResolverLogger>());
+
+  auto managerImplementationFactory =
+      openassetio::python::hostApi::createPythonPluginSystemManagerImplementationFactory(logger_);
+
+  const auto hostInterface = std::make_shared<UsdOpenAssetIOHostInterface>();
+
+  manager_ = openassetio::hostApi::ManagerFactory::defaultManagerForInterface(
+      hostInterface, managerImplementationFactory, logger_);
+
+  if (!manager_) {
+    throw std::invalid_argument{
+        "No default manager configured, " +
+        openassetio::hostApi::ManagerFactory::kDefaultManagerConfigEnvVarName};
+  }
+
+  logger_->debug("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME());
 }
 
 UsdOpenAssetIOResolver::~UsdOpenAssetIOResolver() {
-  TF_DEBUG(OPENASSETIO_RESOLVER).Msg("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME() + "\n");
+  logger_->debug("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME());
 }
 
 std::string UsdOpenAssetIOResolver::_CreateIdentifier(
     const std::string &assetPath, const ArResolvedPath &anchorAssetPath) const {
   auto result = ArDefaultResolver::_CreateIdentifier(assetPath, anchorAssetPath);
-  TF_DEBUG(OPENASSETIO_RESOLVER)
-      .Msg("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME() + "\n  assetPath: " + assetPath +
-           "\n  anchorAssetPath: " + anchorAssetPath.GetPathString() + "\n  result: " + result +
-           "\n");
+
+  logger_->debug("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME());
+  logger_->debug("  assetPath: " + assetPath);
+  logger_->debug("  anchorAssetPath: " + anchorAssetPath.GetPathString());
+  logger_->debug("  result: " + result);
+
   return result;
 }
 
 std::string UsdOpenAssetIOResolver::_CreateIdentifierForNewAsset(
     const std::string &assetPath, const ArResolvedPath &anchorAssetPath) const {
   auto result = ArDefaultResolver::_CreateIdentifierForNewAsset(assetPath, anchorAssetPath);
-  TF_DEBUG(OPENASSETIO_RESOLVER)
-      .Msg("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME() + "\n  assetPath: " + assetPath +
-           "\n  anchorAssetPath: " + anchorAssetPath.GetPathString() + "\n  result: " + result +
-           "\n");
+  logger_->debug("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME());
+
+  logger_->debug("  assetPath: " + assetPath);
+  logger_->debug("  anchorAssetPath: " + anchorAssetPath.GetPathString());
+  logger_->debug("  result: " + result);
+
   return result;
 }
 
 ArResolvedPath UsdOpenAssetIOResolver::_Resolve(const std::string &assetPath) const {
   auto result = ArDefaultResolver::_Resolve(assetPath);
-  TF_DEBUG(OPENASSETIO_RESOLVER)
-      .Msg("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME() + "\n  assetPath: " + assetPath +
-           "\n  result: " + result.GetPathString() + "\n");
+
+  logger_->debug("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME());
+  logger_->debug("  assetPath: " + assetPath);
+  logger_->debug("  result: " + result.GetPathString());
+
   return result;
 }
 
 ArResolvedPath UsdOpenAssetIOResolver::_ResolveForNewAsset(const std::string &assetPath) const {
   auto result = ArDefaultResolver::_ResolveForNewAsset(assetPath);
-  TF_DEBUG(OPENASSETIO_RESOLVER)
-      .Msg("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME() + "\n  assetPath: " + assetPath +
-           "\n  result: " + result.GetPathString() + "\n");
+
+  logger_->debug("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME());
+  logger_->debug("  assetPath: " + assetPath);
+  logger_->debug("  result: " + result.GetPathString());
+
   return result;
 }
 
 /* Asset Operations*/
 std::string UsdOpenAssetIOResolver::_GetExtension(const std::string &assetPath) const {
   auto result = ArDefaultResolver::_GetExtension(assetPath);
-  TF_DEBUG(OPENASSETIO_RESOLVER)
-      .Msg("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME() + "\n  assetPath: " + assetPath +
-           "\n  result: " + result + "\n");
+
+  logger_->debug("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME());
+  logger_->debug("  assetPath: " + assetPath);
+  logger_->debug("  result: " + result);
+
   return result;
 }
 
 ArAssetInfo UsdOpenAssetIOResolver::_GetAssetInfo(const std::string &assetPath,
                                                   const ArResolvedPath &resolvedPath) const {
   auto result = ArDefaultResolver::_GetAssetInfo(assetPath, resolvedPath);
-  TF_DEBUG(OPENASSETIO_RESOLVER)
-      .Msg("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME() + "\n  assetPath: " + assetPath +
-           "\n  resolvedPath :" + resolvedPath.GetPathString() + "\n  result(assetName): " +
-           result.assetName + "\n  result(repoPath): " + result.repoPath + "\n");
+
+  logger_->debug("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME());
+  logger_->debug("  assetPath: " + assetPath);
+  logger_->debug("  resolvedPath: " + resolvedPath.GetPathString());
+  logger_->debug("  result(assetName): " + result.assetName);
+  logger_->debug("  result(repoPath): " + result.repoPath);
+
   return result;
 }
 
 ArTimestamp UsdOpenAssetIOResolver::_GetModificationTimestamp(
     const std::string &assetPath, const ArResolvedPath &resolvedPath) const {
   auto result = ArDefaultResolver::_GetModificationTimestamp(assetPath, resolvedPath);
-  TF_DEBUG(OPENASSETIO_RESOLVER)
-      .Msg("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME() + "\n  assetPath: " + assetPath +
-           "\n  resolvedPath :" + resolvedPath.GetPathString() +
-           "\n  result: " + std::to_string(result.GetTime()) + "\n");
+
+  logger_->debug("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME());
+  logger_->debug("  assetPath: " + assetPath);
+  logger_->debug("  resolvedPath: " + resolvedPath.GetPathString());
+  logger_->debug("  result: " + std::to_string(result.GetTime()));
+
   return result;
 }
 
 std::shared_ptr<ArAsset> UsdOpenAssetIOResolver::_OpenAsset(
     const ArResolvedPath &resolvedPath) const {
-  TF_DEBUG(OPENASSETIO_RESOLVER)
-      .Msg("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME() +
-           "\n  resolvedPath :" + resolvedPath.GetPathString() + "\n");
+  logger_->debug("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME());
+  logger_->debug("  resolvedPath: " + resolvedPath.GetPathString());
+
   return ArDefaultResolver::_OpenAsset(resolvedPath);
 }
 
 bool UsdOpenAssetIOResolver::_CanWriteAssetToPath(const ArResolvedPath &resolvedPath,
                                                   std::string *whyNot) const {
   auto result = ArDefaultResolver::CanWriteAssetToPath(resolvedPath, whyNot);
-  TF_DEBUG(OPENASSETIO_RESOLVER)
-      .Msg("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME() +
-           "\n  resolvedPath :" + resolvedPath.GetPathString() +
-           "\n  result: " + std::to_string(static_cast<int>(result)) + "\n");
+
+  logger_->debug("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME());
+  logger_->debug("  resolvedPath: " + resolvedPath.GetPathString());
+  logger_->debug("  result: " + std::to_string(static_cast<int>(result)));
+
   return result;
 }
 
 std::shared_ptr<ArWritableAsset> UsdOpenAssetIOResolver::_OpenAssetForWrite(
     const ArResolvedPath &resolvedPath, WriteMode writeMode) const {
-  TF_DEBUG(OPENASSETIO_RESOLVER)
-      .Msg("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME() +
-           "\n  resolvedPath :" + resolvedPath.GetPathString() + "\n");
+  logger_->debug("OPENASSETIO_RESOLVER: " + TF_FUNC_NAME());
+  logger_->debug("  resolvedPath: " + resolvedPath.GetPathString());
+
   return ArDefaultResolver::_OpenAssetForWrite(resolvedPath, writeMode);
 }

--- a/src/resolver.h
+++ b/src/resolver.h
@@ -7,6 +7,11 @@
 
 #include <pxr/usd/ar/defaultResolver.h>
 
+#include <openassetio/typedefs.hpp>
+
+OPENASSETIO_FWD_DECLARE(hostApi, Manager)
+OPENASSETIO_FWD_DECLARE(log, LoggerInterface)
+
 class UsdOpenAssetIOResolver final : public PXR_NS::ArDefaultResolver {
  public:
   UsdOpenAssetIOResolver();
@@ -44,4 +49,8 @@ class UsdOpenAssetIOResolver final : public PXR_NS::ArDefaultResolver {
       const PXR_NS::ArResolvedPath &resolvedPath, WriteMode writeMode) const final;
 
  private:
+  /// OpenAssetIO Logger. Uses TF Log/Error functions.
+  openassetio::log::LoggerInterfacePtr logger_;
+  /// OpenAssetIO Manager. Initialised on construction.
+  openassetio::hostApi::ManagerPtr manager_;
 };

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,2 @@
 pytest==6.2.4
+openassetio-manager-bal==1.0.0a5

--- a/tests/resources/openassetio.conf
+++ b/tests/resources/openassetio.conf
@@ -1,0 +1,2 @@
+[manager]
+identifier = "org.openassetio.examples.manager.bal"

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -21,7 +21,7 @@ from pxr import Plug, Usd, Ar
 # This test can be removed once the logging transforms, alchemy like,
 # into real functionality.
 def test_open_stage_and_logging(capfd):
-    Usd.Stage.Open("resources/empty_shot.usda")
+    open_stage("resources/empty_shot.usda")
     captured = capfd.readouterr()
 
     outputs = captured.out.split(os.environ["TF_DEBUG"])

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -119,6 +119,12 @@ def openassetio_configured():
     ), "usdOpenAssetIOResolver plugin not loaded, please check PXR_PLUGINPATH_NAME env variable"
 
 
+# Log openassetio resolver messages
+@pytest.fixture(autouse=True)
+def enable_openassetio_logging_debug():
+    os.environ["OPENASSETIO_LOGGING_SEVERITY"] = "1"
+
+
 # As all the data tends to follow the same form, convenience method
 # to avoid repeating myself
 def assert_parking_lot_structure(usd_stage):


### PR DESCRIPTION
Closes #15 

Add OpenAssetIO as a dependency of the resolver, so that OpenAssetIO methods can be use to implement resolver interface methods.

Add OpenAssetIO building to the test automation along with this. We use the OpenAssetIIO docker container to make getting dependencies for the build easier, and then move the build made inside that container between jobs, (helpfully, our container and the vfxall container are the same base, intentionally, so this is compatible.)

Doing this also means we end up writing an openassetio logger interface implementation, which while it's tested insofar as we know it logs things, it could be tested more thoroughly. However, OpenAssetIO currently only sets severity upon construction, which is problematic to test when it's puppeted by something else.