### PR TITLE
[Core] Prevent exception propagation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,4 +61,4 @@ jobs:
           export OPENASSETIO_DEFAULT_CONFIG=$GITHUB_WORKSPACE/tests/resources/openassetio.conf
           export PYTHONPATH=/usr/local/lib/python/:$GITHUB_WORKSPACE/openassetio-build/lib/python3.9/site-packages
           cd tests
-          python -m pytest . -v
+          python -m pytest -v --capture=tee-sys .

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -14,6 +14,9 @@ root=.
 # -readability/casting: Causes false positives with Trompeloeil mocks,
 #   where CppLint seems to think a macro is actually a C-style cast.
 #   This check is also performed by Clang-Tidy, anyway.
+# -build/c++11 Causes e.g. "<thread> is an unapproved C++11 header",
+#   which is specific for Chromium devs, apparently.
 filter=-runtime/references,-readability/nolint,-readability/check,-whitespace/braces
 filter=-readability/casting
 filter=-build/include_subdir
+filter=-build/c++11

--- a/tests/resources/integration_test_data/error_triggering_asset_ref/parking_lot.usd
+++ b/tests/resources/integration_test_data/error_triggering_asset_ref/parking_lot.usd
@@ -1,0 +1,11 @@
+#usda 1.0
+
+def "ParkingLot"
+{
+    def "ParkingLot_Floor_1" (
+        references = @bal:///@</ParkingLot_Floor>
+    )
+    {
+    }
+}
+

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -103,6 +103,20 @@ def test_non_assetized_child_ref_assetized_grandchild():
     assert_parking_lot_structure(stage)
 
 
+# Will attempt to resolve `bal:///` (i.e. no path component), which
+# will trigger an exception in BAL internals.
+def test_error_triggering_asset_ref(capfd):
+    open_stage(
+        "resources/integration_test_data/error_triggering_asset_ref/parking_lot.usd"
+    )
+
+    logs = capfd.readouterr()
+    assert (
+        "OpenAssetIO error in UsdOpenAssetIOResolver::_GetExtension: RuntimeError: error code 130:"
+        in logs.err
+    )
+
+
 ##### Utility Functions #####
 
 # Verify OpenAssetIO configured as the AR resolver.

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -26,15 +26,22 @@ def test_open_stage_and_logging(capfd):
     open_stage("resources/empty_shot.usda")
     captured = capfd.readouterr()
 
-    outputs = captured.out.split(os.environ["TF_DEBUG"])
-    assert "UsdOpenAssetIOResolver::UsdOpenAssetIOResolver" in outputs[1]
+    outputs = captured.out.split("UsdOpenAssetIOResolver::")
+    assert "UsdOpenAssetIOResolver" in outputs[1]
     assert "_CreateIdentifier" in outputs[2]
+    assert "result" in outputs[2]
     assert "_Resolve" in outputs[3]
+    assert "result" in outputs[3]
     assert "_GetExtension" in outputs[4]
+    assert "result" in outputs[4]
     assert "_GetAssetInfo" in outputs[5]
+    assert "result" in outputs[5]
     assert "_OpenAsset" in outputs[6]
+    assert "result" in outputs[6]
     assert "_GetModificationTimestamp" in outputs[7]
+    assert "result" in outputs[7]
     assert "_GetExtension" in outputs[8]
+    assert "result" in outputs[8]
 
 
 # Given a USD document that references an asset via a direct relative


### PR DESCRIPTION
Part of #15. USD cannot handle exceptions being thrown during stage resolution and will terminate the application (sigabrt/segfault).

Best guess so far for the expected error behaviour is to return a default-constructed object (e.g. empty string, invalid timestamp, etc).

So add and use a decorator that will catch all exceptions and log them before returning a default-constructed object.