### PR TITLE
[CI] Use newer USD build to fix Python deadlock

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-openassetio
     container:
-      image: aswf/ci-vfxall:2022-clang13.1
+      image: aswf/ci-vfxall:2022-clang14.3
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Fixes #22. The current build of `aswf/ci-vfxall:2022-clang13.1` seems to bundle a USD build based off a bugged commit, where the Python GIL is held whilst loading the stage, precluding plugins running in other threads from accessing Python.

This seems to be fixed in USD in commit [9599c49c](https://github.com/PixarAnimationStudios/USD/commit/9599c49c), which came after the ASWF `2022-clang-13.1` image was last updated, but before the `2022-clang14.3` image was last updated.