### PR TITLE
[Core] Support OpenAssetIO 1.0.0-beta.1.0

### DIFF
--- a/.github/build_openassetio_mediacreation/action.yml
+++ b/.github/build_openassetio_mediacreation/action.yml
@@ -22,7 +22,7 @@ runs:
         cd openassetio-mediacreation-checkout
         mkdir build
         python -m pip install openassetio-traitgen
-        cmake -G Ninja -S . -B build
+        cmake -G Ninja -S . -B build -DOPENASSETIO_MEDIACREATION_GENERATE_PYTHON=ON
         cmake --build build
         cmake --install build
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,6 @@ jobs:
           export PXR_PLUGINPATH_NAME=$GITHUB_WORKSPACE/build/dist/resources/plugInfo.json
           export LD_LIBRARY_PATH=/usr/local/lib:$GITHUB_WORKSPACE/openassetio-build/lib64
           export OPENASSETIO_DEFAULT_CONFIG=$GITHUB_WORKSPACE/tests/resources/openassetio.conf
-          export PYTHONPATH=/usr/local/lib/python/:$GITHUB_WORKSPACE/openassetio-build/lib/python3.9/site-packages
+          export PYTHONPATH=/usr/local/lib/python/:$GITHUB_WORKSPACE/openassetio-build/lib/python3.9/site-packages:$GITHUB_WORKSPACE/openassetio-mediacreation-build/lib/python3.9/site-packages
           cd tests
           python -m pytest -v --capture=tee-sys .

--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -3,10 +3,8 @@
 
 #include "resolver.h"
 
-#include <sstream>
 #include <stdexcept>
 #include <thread>
-#include <utility>
 
 #include <pxr/base/tf/debug.h>
 #include <pxr/base/tf/diagnostic.h>
@@ -15,7 +13,6 @@
 #include <pxr/usd/ar/defineResolver.h>
 
 #include <openassetio/Context.hpp>
-#include <openassetio/TraitsData.hpp>
 #include <openassetio/access.hpp>
 #include <openassetio/hostApi/HostInterface.hpp>
 #include <openassetio/hostApi/Manager.hpp>
@@ -24,6 +21,7 @@
 #include <openassetio/log/LoggerInterface.hpp>
 #include <openassetio/log/SeverityFilter.hpp>
 #include <openassetio/python/hostApi.hpp>
+#include <openassetio/trait/TraitsData.hpp>
 
 #include <openassetio_mediacreation/traits/content/LocatableContentTrait.hpp>
 
@@ -120,7 +118,7 @@ std::string resolveToPath(const openassetio::hostApi::ManagerPtr &manager,
 
   // Resolve the locatable content trait, this will provide a URL
   // that points to the final content
-  openassetio::TraitsDataPtr traitsData = manager->resolve(
+  const openassetio::trait::TraitsDataPtr traitsData = manager->resolve(
       entityReference, {LocatableContentTrait::kId}, ResolveAccess::kRead, context);
 
   // OpenAssetIO is URL based, but we need a path, so check the
@@ -209,6 +207,11 @@ UsdOpenAssetIOResolver::UsdOpenAssetIOResolver() {
     throw std::invalid_argument{
         "No default manager configured, " +
         openassetio::hostApi::ManagerFactory::kDefaultManagerConfigEnvVarName};
+  }
+
+  if (!manager_->hasCapability(openassetio::hostApi::Manager::Capability::kResolution)) {
+    throw std::invalid_argument{manager_->displayName() +
+                                " is not capable of resolving entity references"};
   }
 
   context_ = openassetio::Context::make();

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,6 @@
 pytest==6.2.4
+# pytest plugin that adds @pytest.mark.forked to flag a test that should
+# run in a forked subprocess. Useful for testing global initialization
+# code paths.
+pytest-forked==1.6.0
 openassetio-manager-bal


### PR DESCRIPTION
Update to use non-deprecated `TraitsData` header/namespace.

Fix expected exception type.
