### PR TITLE
Refresh tests, use correct BAL

### DIFF
--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -14,6 +14,7 @@
 
 #include <openassetio/Context.hpp>
 #include <openassetio/access.hpp>
+#include <openassetio/errors/exceptions.hpp>
 #include <openassetio/hostApi/HostInterface.hpp>
 #include <openassetio/hostApi/Manager.hpp>
 #include <openassetio/hostApi/ManagerFactory.hpp>
@@ -165,7 +166,7 @@ auto catchAndLogExceptions(Fn &&fn, const openassetio::log::LoggerInterfacePtr &
                            const std::string_view name) {
   try {
     return fn();
-  } catch (const std::exception &exc) {
+  } catch (const openassetio::errors::OpenAssetIOException &exc) {
     std::string msg = "OpenAssetIO error in ";
     msg += name;
     msg += ": ";

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,4 +3,4 @@ pytest==6.2.4
 # run in a forked subprocess. Useful for testing global initialization
 # code paths.
 pytest-forked==1.6.0
-openassetio-manager-bal
+git+https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL.git


### PR DESCRIPTION
There are a couple of things that needed fixing up on account of this repo not having run for months.

- BAL and OpenAssetIO were out of sync, not normally a problem, but with the introduction of a new required capability, this caused errors. Ideally we'd pin both here, but as we neccesarily need to build C++ artifacts at the moment, it's simpler to just get BAL from head to match how we get OpenAssetIO.

- A pretty gnarly RTTI, diamond inheritance exception issue, that I have not solved but simply worked around for the moment. See https://github.com/OpenAssetIO/OpenAssetIO/issues/1225 for more info.