### PR TITLE
Default to CY24 and drop support for CY22 

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -8,9 +8,9 @@ concurrency:
 jobs:
   pylint:
     name: Pylint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
-      image: aswf/ci-vfxall:2022-clang13.1
+      image: ghcr.io/openassetio/openassetio-build
     steps:
       - uses: actions/checkout@v3
 
@@ -27,7 +27,7 @@ jobs:
           pylint-paths: >
             tests
   black:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Python formatting
     steps:
       - uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |
@@ -66,14 +66,10 @@ jobs:
 
   cpp-linters:
     name: C++ linters
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build-openassetio
     container:
-      image: aswf/ci-vfxall:2022-clang13.1
-    strategy:
-      matrix:
-        config:
-          - os: ubuntu-20.04
+      image: ghcr.io/openassetio/openassetio-build
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2023 The Foundry Visionmongers Ltd
+# Copyright 2023-2024 The Foundry Visionmongers Ltd
 
 # Runs pytest on the matrix of supported platforms any Python versions.
 name: Test
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-openassetio
     container:
-      image: aswf/ci-vfxall:2022-clang14.3
+      image: ghcr.io/openassetio/openassetio-build
     steps:
       - uses: actions/checkout@v3
 
@@ -65,7 +65,7 @@ jobs:
         # PYTHONPATH here is extended with `/usr/local/lib/python`
         # because the USD install on this docker container is odd, and
         # stores the `pxr` lib in that space, whilst the regular python
-        # libraries are contained at /usr/local/lib/python3.9,
+        # libraries are contained at /usr/local/lib/python3.11,
         # (which is already on the pythonpath)
         #
         # LD_LIBRARY_PATH doesn't have /usr/local/lib on it by default
@@ -74,8 +74,7 @@ jobs:
       - name: Test
         run: |
           export PXR_PLUGINPATH_NAME=$GITHUB_WORKSPACE/build/dist/resources/plugInfo.json
-          export LD_LIBRARY_PATH=/usr/local/lib:$GITHUB_WORKSPACE/openassetio-build/lib64
-          export OPENASSETIO_DEFAULT_CONFIG=$GITHUB_WORKSPACE/tests/resources/openassetio.conf
-          export PYTHONPATH=/usr/local/lib/python/:$GITHUB_WORKSPACE/openassetio-build/lib/python3.9/site-packages:$GITHUB_WORKSPACE/openassetio-mediacreation-build/lib/python3.9/site-packages
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/openassetio-build/lib64
+          export PYTHONPATH=/usr/local/lib/python/:$GITHUB_WORKSPACE/openassetio-build/lib/python3.11/site-packages:$GITHUB_WORKSPACE/openassetio-mediacreation-build/lib/python3.11/site-packages
           cd tests
           python -m pytest -v --capture=tee-sys .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,19 +39,6 @@ option(OPENASSETIO_USDRESOLVER_ENABLE_CLANG_TIDY "Enable clang-tidy analysis dur
 # Enable cpplint linter.
 option(OPENASSETIO_USDRESOLVER_ENABLE_CPPLINT "Enable cpplint linter during build" OFF)
 
-
-# Disable C++11 ABI by default, as per current VFX reference
-# platform(s), but allow optionally enabling.
-# For reference, note that the default varies by platform, e.g.
-# * CentOS 7.9.2009's GCC 6.3, `_GLIBCXX_USE_CXX11_ABI` is
-#   always `0` and cannot be overridden.
-# * Ubuntu 18.04's GCC 6.5, `_GLIBCXX_USE_CXX11_ABI` defaults
-#   to `1`, but can be overridden.
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 5.0)
-    option(OPENASSETIO_USDRESOLVER_GLIBCXX_USE_CXX11_ABI "For gcc, use the new C++11 library ABI" OFF)
-endif ()
-
 # Add Static analysis targets
 include(StaticAnalyzers)
 if (OPENASSETIO_USDRESOLVER_ENABLE_CLANG_FORMAT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,14 +52,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
     option(OPENASSETIO_USDRESOLVER_GLIBCXX_USE_CXX11_ABI "For gcc, use the new C++11 library ABI" OFF)
 endif ()
 
-
-# Find USD.
-find_package(pxr REQUIRED)
-
-# Find OpenAssetIO
-find_package(OpenAssetIO REQUIRED)
-find_package(OpenAssetIO-MediaCreation REQUIRED)
-
 # Add Static analysis targets
 include(StaticAnalyzers)
 if (OPENASSETIO_USDRESOLVER_ENABLE_CLANG_FORMAT)
@@ -72,11 +64,28 @@ if (OPENASSETIO_USDRESOLVER_ENABLE_CPPLINT)
     enable_cpplint()
 endif ()
 
+
+#-----------------------------------------------------------------------
+# Dependencies
+
+# Find USD.
+find_package(pxr REQUIRED)
+
+# Find OpenAssetIO
+find_package(OpenAssetIO REQUIRED)
+find_package(OpenAssetIO-MediaCreation REQUIRED)
+
+
+#-----------------------------------------------------------------------
+# Recurse to sources
+
 include(DefaultTargetProperties)
 add_subdirectory(src)
 
+
 #-----------------------------------------------------------------------
 # Print a status dump
+
 message(STATUS "Warnings as errors              = ${OPENASSETIO_USDRESOLVER_WARNINGS_AS_ERRORS}")
 message(STATUS "Linter: clang-tidy              = ${OPENASSETIO_USDRESOLVER_ENABLE_CLANG_TIDY} [${OPENASSETIO_USDRESOLVER_CLANGTIDY_EXE}]")
 message(STATUS "Linter: cpplint                 = ${OPENASSETIO_USDRESOLVER_ENABLE_CPPLINT} [${OPENASSETIO_USDRESOLVER_CPPLINT_EXE}]")

--- a/README.md
+++ b/README.md
@@ -111,17 +111,6 @@ cmake --build build
 cmake --install build
 ```
 
-> **Note**
->
-> VFX Reference Platform CY2022 requires the old pre c++11 ABI, which is
-> used by default for `gcc` builds of these projects. It is important
-> that `usdOpenAssetIOResolver`, `OpenAssetIO` and `USD` are all built
-> under the same ABI.
->
-> You can build under the new ABI by appending
-> `-DOPENASSETIO_USDRESOLVER_GLIBCXX_USE_CXX11_ABI=On` to your configure
-> command.
-
 ## Running
 
 To enable the resolver, before running any USD application, you must set

--- a/cmake/DefaultTargetProperties.cmake
+++ b/cmake/DefaultTargetProperties.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2013-2022 The Foundry Visionmongers Ltd
+# Copyright 2013-2024 The Foundry Visionmongers Ltd
 
 include(CompilerWarnings)
 
@@ -7,7 +7,7 @@ function(openassetio_usdresolver_set_default_target_properties target_name)
     #-------------------------------------------------------------------
     # C++ standard
 
-    # Minimum C++ standard as per current VFX reference platform CY21+.
+    # Minimum C++ standard as per current VFX reference platform CY23+.
     target_compile_features(${target_name} PRIVATE cxx_std_17)
 
     set_target_properties(
@@ -41,16 +41,6 @@ function(openassetio_usdresolver_set_default_target_properties target_name)
     if (IS_GCC_OR_CLANG AND NOT APPLE)
         # TODO(TC): Find a way to hide symbols on macOS
         target_link_options(${target_name} PRIVATE "-Wl,--exclude-libs,ALL")
-    endif ()
-
-    # Whether to use the old or new C++ ABI with gcc.
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
-        CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 5.0)
-        if (OPENASSETIO_USDRESOLVER_GLIBCXX_USE_CXX11_ABI)
-            target_compile_definitions(${target_name} PRIVATE _GLIBCXX_USE_CXX11_ABI=1)
-        else ()
-            target_compile_definitions(${target_name} PRIVATE _GLIBCXX_USE_CXX11_ABI=0)
-        endif ()
     endif ()
 
     #-------------------------------------------------------------------

--- a/resources/build/linter-requirements.txt
+++ b/resources/build/linter-requirements.txt
@@ -1,3 +1,3 @@
 cpplint==1.5.5
 black==24.3.0
-pylint==2.12.2
+pylint==2.17.2


### PR DESCRIPTION
Part of https://github.com/OpenAssetIO/OpenAssetIO/issues/1351.

Remove support for changing the libstdc++ ABI version, since that was only necessary to support CY22.

The updated `openassetio-build` Docker image conforms to CY24. So update usages of other `aswf` images to also conform to CY24.