### PR TITLE
Use OpenAssetIO context from manager

### DIFF
--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -118,7 +118,7 @@ class UsdOpenAssetIOResolver final : public PXR_NS::ArDefaultResolver {
       throw std::invalid_argument{manager_->displayName() +
                                   " is not capable of resolving entity references"};
     }
-    context_ = openassetio::Context::make();
+    context_ = manager_->createContext();
   }
 
   ~UsdOpenAssetIOResolver() override = default;


### PR DESCRIPTION
The Context instance is passed into every API method. The Context may bundle arbitrary state from the manager. In order for the Context to be created with the appropriate state by the manager, the host is required to construct a Context object using the `Manager.createContext()` method. However, we were not doing that and instead constructed the Context directly, which should never be done (other than for trivial cases e.g. unit tests).

Note that this cannot be unit tested easily - currently our mock manager BAL does not make use of the Context.